### PR TITLE
Added media queries in style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,3 +54,14 @@
       stroke-width:3;
       cursor: pointer;
   }
+  /* Fix for Issue #70*/
+  @media(max-width:750px) {
+    .entry {
+        width: 40%;
+    }
+}
+@media(max-width: 476px) {
+    .entry {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
Fix for Issue #70. 
Added two media queries to rearrange the way the list are displayed for different resolutions. This resolves the issue of column overlapping. Screenshots below:
1) resolution > 750px, three columns displayed
![image](https://user-images.githubusercontent.com/21130598/47391886-dd0d2280-d6cf-11e8-9d93-44202bbebb54.png)

2)476<resolution <=750px, two columns displayed
![image](https://user-images.githubusercontent.com/21130598/47391982-1776bf80-d6d0-11e8-9593-0411ad7dec3e.png)

3) resolution <=476px, single column displayed
![image](https://user-images.githubusercontent.com/21130598/47392101-6d4b6780-d6d0-11e8-8d17-6512475d8a60.png)

Please review and let me know if any changes needed. Thank you!





